### PR TITLE
Fix to refunds and for EDH regular giving.

### DIFF
--- a/lib/tns_payments/connection.rb
+++ b/lib/tns_payments/connection.rb
@@ -41,7 +41,7 @@ module TNSPayments
         'transaction'  => {
           'amount'    => transaction.amount.to_s,
           'currency'  => transaction.currency,
-          'reference' => transaction.reference
+          'reference' => transaction.reference.to_s
         }
       }
 
@@ -60,7 +60,7 @@ module TNSPayments
         'transaction'  => {
           'amount'    => transaction.amount.to_s,
           'currency'  => transaction.currency,
-          'reference' => transaction_id.to_s
+          'reference' => transaction.reference.to_s
         }
       }
 


### PR DESCRIPTION
TNS insist that the reference be a string or they 500 on us. 
Also I missed setting the reference correctly for refunds.
